### PR TITLE
Implement BG95 GNSS HTTP reporting with periodic low-power loop

### DIFF
--- a/gps-hw.X/main.c
+++ b/gps-hw.X/main.c
@@ -46,6 +46,80 @@
   Section: Included Files
 */
 #include "mcc_generated_files/system.h"
+#include "mcc_generated_files/uart1.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#define FCY (_XTAL_FREQ/2)
+#include <libpic30.h>
+
+#define HTTP_URL "http://example.com/position"
+
+static void BG95_SendString(const char *s)
+{
+    while (*s)
+    {
+        while (!UART1_IsTxReady());
+        UART1_Write(*s++);
+    }
+}
+
+static void BG95_ReadLine(char *buffer, size_t len)
+{
+    size_t i = 0;
+
+    while (i < len - 1)
+    {
+        while (!UART1_IsRxReady());
+        char c = UART1_Read();
+        buffer[i++] = c;
+        if (c == '\n')
+        {
+            break;
+        }
+    }
+
+    buffer[i] = '\0';
+}
+
+static void BG95_GetPosition(char *pos, size_t len)
+{
+    BG95_SendString("AT+QGPS=1\r\n");
+    __delay_ms(1000);
+    BG95_SendString("AT+QGPSLOC=2\r\n");
+    BG95_ReadLine(pos, len);
+}
+
+static void BG95_PostPosition(const char *pos)
+{
+    char cmd[128];
+    char body[128];
+
+    snprintf(body, sizeof(body), "{\"pos\":\"%s\"}", pos);
+
+    BG95_SendString("AT+QHTTPCFG=\"contenttype\",\"application/json\"\r\n");
+    __delay_ms(100);
+    snprintf(cmd, sizeof(cmd), "AT+QHTTPURL=%u,80\r\n", (unsigned)strlen(HTTP_URL));
+    BG95_SendString(cmd);
+    __delay_ms(100);
+    BG95_SendString(HTTP_URL);
+    BG95_SendString("\r\n");
+    __delay_ms(100);
+    snprintf(cmd, sizeof(cmd), "AT+QHTTPPOST=%u,80,80\r\n", (unsigned)strlen(body));
+    BG95_SendString(cmd);
+    __delay_ms(100);
+    BG95_SendString(body);
+    BG95_SendString("\r\n");
+}
+
+static void SleepOneMinute(void)
+{
+    RCONbits.SWDTEN = 1;
+    __builtin_clrwdt();
+    Sleep();
+    RCONbits.SWDTEN = 0;
+}
 
 /*
                          Main application
@@ -57,7 +131,11 @@ int main(void)
 
     while (1)
     {
-        // Add your application code
+        char position[64];
+
+        BG95_GetPosition(position, sizeof(position));
+        BG95_PostPosition(position);
+        SleepOneMinute();
     }
 
     return 1;


### PR DESCRIPTION
## Summary
- Add UART helper functions for BG95 communication and HTTP requests
- Query GNSS position and post results via BG95 LTE modem
- Sleep MCU with watchdog between 1-minute reporting cycles

## Testing
- `make` *(fails: /Applications/microchip/xc16/v2.10/bin/xc16-gcc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b67718cffc832a90a139d1a185afc6