### PR TITLE
Enable software-controlled watchdog timer

### DIFF
--- a/gps-hw.X/gps-hw.mc3
+++ b/gps-hw.X/gps-hw.mc3
@@ -8037,7 +8037,7 @@
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.SettingKey" moduleName="System Module" registerAlias="FWDT" settingAlias="FWDTEN"/>
-         <value>OFF</value>
+         <value>ON_SWDTEN</value>
       </entry>
       <entry>
          <key class="com.microchip.mcc.core.tokenManager.SettingKey" moduleName="System Module" registerAlias="FWDT" settingAlias="FWPSA"/>

--- a/gps-hw.X/mcc_generated_files/system.c
+++ b/gps-hw.X/mcc_generated_files/system.c
@@ -73,7 +73,7 @@
 // FWDT
 #pragma config WDTPS = PS32768    //Watchdog Timer Postscaler bits->1:32768
 #pragma config FWPSA = PR128    //Watchdog Timer Prescaler bit->1:128
-#pragma config FWDTEN = OFF    //Watchdog Timer Enable bits->WDT and SWDTEN disabled
+#pragma config FWDTEN = ON_SWDTEN    //Watchdog Timer Enable bits->WDT is disabled; controlled by SWDTEN bit
 #pragma config WINDIS = OFF    //Watchdog Timer Window Enable bit->Watchdog Timer in Non-Window mode
 #pragma config WDTWIN = WIN25    //Watchdog Timer Window Select bits->WDT Window is 25% of WDT period
 #pragma config WDTCMX = WDTCLK    //WDT MUX Source Select bits->WDT clock source is determined by the WDTCLK Configuration bits


### PR DESCRIPTION
## Summary
- Allow software to enable watchdog timer by default
- Update MCC configuration to reflect new watchdog setting

## Testing
- `make -C gps-hw.X` *(fails: /Applications/microchip/xc16/v2.10/bin/xc16-gcc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b680f89bd4832a87c6f6edbd57e8df